### PR TITLE
fix multi-node bug when use io.adapter()

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ module.exports = class IO {
     }
 
     // Local aliases / passthrough socket.io functionality
-    this.adapter = app._io.adapter;
+    this.adapter = app._io.adapter.bind(app._io);
 
     // Attach default namespace
     app.io = this;


### PR DESCRIPTION
fix context error
"this" is depend in socket.io's code
=====================================
Server.prototype.adapter = function(v){
  if (!arguments.length) return this._adapter;
  this._adapter = v;
  for (var i in this.nsps) {
    if (this.nsps.hasOwnProperty(i)) {
      this.nsps[i].initAdapter();
    }
  }
  return this;
};