### PR TITLE
Upgrade to socket.io v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 > Sugar for connecting socket.io to a Koa instance
 
-**Koa-socket-2 uses socket.io v2.  It is recommended that you connect to a koa-socket-2 server with a socket.io v2 client.**
+**Koa-socket-2 uses socket.io v3.  It is recommended that you connect to a koa-socket-2 server with a socket.io v3 client.**
 
 Koa-socket-2 is only compatible with Koa v2 style of middleware (where context is passed as a parameter).
 

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ module.exports = class IO {
       throw new Error( 'Default namespace can not be hidden' );
     }
 
-    app._io = new socketIO( app.server, this.opts.ioOptions );
+    app._io = socketIO( app.server, this.opts.ioOptions );
 
     if ( this.opts.namespace ) {
       this.attachNamespace( app, this.opts.namespace );

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "coveralls": "^3.0.0",
     "istanbul": "^0.4.5",
     "istanbul-harmony": "^0.3.16",
+    "glob": "^7.1.6",
     "koa": "^2.7.0",
     "minimist": "^1.2.0",
     "socket.io-client": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "node spec/index.js spec/*.test.js",
-    "cover": "istanbul cover --report lcovonly --print detail spec/index.js spec/*.test.js",
-    "travis": "npm run cover && cat coverage/lcov.info | coveralls",
+    "cover": "nyc npm run test",
+    "travis": "npm run cover && nyc report --reporter=text-lcov | coveralls",
     "example": "node example/server"
   },
   "keywords": [
@@ -35,11 +35,10 @@
   },
   "devDependencies": {
     "coveralls": "^3.0.0",
-    "istanbul": "^0.4.5",
-    "istanbul-harmony": "^0.3.16",
     "glob": "^7.1.6",
     "koa": "^2.7.0",
     "minimist": "^1.2.0",
+    "nyc": "^15.1.0",
     "socket.io-client": "^2.0.1",
     "tape": "^4.6.3"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-socket-2",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Koa meets socket.io connected socket",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "koa-compose": "^4.1.0",
-    "socket.io": "^2.2.0"
+    "socket.io": "^3.0.2"
   },
   "devDependencies": {
     "coveralls": "^3.0.0",
@@ -39,7 +39,7 @@
     "koa": "^2.7.0",
     "minimist": "^1.2.0",
     "nyc": "^15.1.0",
-    "socket.io-client": "^2.0.1",
+    "socket.io-client": "^3.0.2",
     "tape": "^4.6.3"
   }
 }


### PR DESCRIPTION
Apparently upgrading was easier than I thought. I cannot completely judge whether I caught all edge cases, but I went through the migration guide and searched for deprecated/replaced functions in the koa-socket-2 code. The tests run fine.

On a side node, I have replaced the deprecated `istanbul` code coverage tool with `nyc`, I hope that's okay.

Note that the changes are not backwards-compatible! Projects using koa-socket-2 and socket.io-client v2 will not work after the upgrade, without also upgrading the socket.io-client to v3! Therefore I changed the major version of koa-socket-2 to 2.

Fixes #21 